### PR TITLE
Corrected dapper link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ We recommend using a service account with the necessary permissions for monitori
 Open Source Projects in Use
 ---------
 [BookSleeve](https://code.google.com/p/booksleeve/) by Marc Gravell  
-[Dapper](https://github.com/SamSaffron/dapper-dot-net) by Stack Exchange  
+[Dapper](https://github.com/StackExchange/dapper-dot-net/) by Stack Exchange  
 [JSON.Net](http://james.newtonking.com/json) by James Newton-King     
 [MiniProfiler](http://miniprofiler.com/) by Stack Exchange  
 [NEST](https://github.com/Mpdreamz/NEST) by Martijn Laarman  


### PR DESCRIPTION
Dapper link pointed to old Sam Saffron repo.
